### PR TITLE
Added so-patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 **/*config.local*
 scripts/serviceowners.local.json
+scripts/scopes.local.json
 scripts/exported
 scripts/imported
 secrets

--- a/scripts/scope.ps1
+++ b/scripts/scope.ps1
@@ -5,20 +5,19 @@
 # -----------------------------------------------------------------------------------------------------------------
 #
 # Examples: 
-# ./scope.ps1 get -prefix altinn
-# ./scope.ps1 get -scope altinn:foo 
-# ./scope.ps1 new -file definition.json
-# ./scope.ps1 new -definition $definition
-# ./scope.ps1 update -file definition.json
-# ./scope.ps1 update -definition $definition
-# ./scope.ps1 update -definition $definition
-# ./scope.ps1 export-to-csv -prefix altinn
-# ./scope.ps1 import-from-csv -file somefile.csv
-# ./scope.ps1 export-to-json -prefix altinn
+# ./scope get -prefix altinn
+# ./scope get -scope altinn:foo 
+# ./scope new -file definition.json
+# ./scope new -definition $definition
+# ./scope update -file definition.json
+# ./scope update -definition $definition
+# ./scope update -definition $definition
+# ./scope export-to-csv -prefix altinn
+# ./scope import-from-csv -file somefile.csv
+# ./scope export-to-json -prefix altinn
 # 
-# Environment defaults to "VER2". Can be overridden by supplying a -env parameter containing "test1", "ver1", ver2" or "prod"
+# Environment defaults to "test". Can be overridden by supplying a -env parameter containing "test" or "prod"
 # 
-
 
 param (
     [Parameter(Mandatory=$true)][string]$operator,
@@ -26,7 +25,7 @@ param (
     [Parameter()][string]$file,
     [Parameter()][string]$definition,
     [Parameter()][string]$prefix,
-    [Parameter()][string]$env = "ver2"
+    [Parameter()][string]$env = "test"
 )
 
 . ($PSScriptRoot + "/config.ps1")

--- a/scripts/scopeaccess.ps1
+++ b/scripts/scopeaccess.ps1
@@ -5,11 +5,12 @@
 # -----------------------------------------------------------------------------------------------------------------
 #
 # Examples: 
-# ./scopeaccess.ps1 get someprefix:somescope                -> Returns a list of organizations with access to someprefix:somescope
-# ./scopeaccess.ps1 getorg 912345678                        -> Returns a list of scopes granted a organizations
-# ./scopeaccess.ps1 get someprefix:somescope 912345678      -> Returns the scope access for a given scope and organization
-# ./scopeaccess.ps1 remove someprefix:somescope 912345678   -> Revoke 912345678 access to someprefix:somescope
-# ./scopeaccess.ps1 add someprefix:somescope 912345678      -> Grant 912345678 access to someprefix:somescope
+# ./scopeaccess get someprefix:somescope                -> Returns a list of organizations with access to someprefix:somescope
+# ./scopeaccess getorg 912345678                        -> Returns a list of scopes granted an organization
+# ./scopeaccess get someprefix:somescope 912345678      -> Returns the scope access for a given scope and organization
+# ./scopeaccess remove someprefix:somescope 912345678   -> Revoke 912345678 access to someprefix:somescope
+# ./scopeaccess add someprefix:somescope 912345678      -> Grant 912345678 access to someprefix:somescope
+# ./scopeaccess listprefix someprefix:somescope         -> List all scopes starting with someprefix:somescope
 # 
 # Environment defaults to "TEST". Can be overridden by supplying a fourth positional or -env parameter containing "test" or "prod"
 

--- a/scripts/scopes.json
+++ b/scripts/scopes.json
@@ -1,0 +1,8 @@
+{
+    "scopes": [
+        "altinn:serviceowner",
+        "altinn:serviceowner/instances.read",
+        "altinn:serviceowner/instances.write",
+        "altinn:serviceowner/notifications.create"
+    ]
+}

--- a/scripts/so-patch.ps1
+++ b/scripts/so-patch.ps1
@@ -1,0 +1,141 @@
+# Script to patch which scopes a service owner has access to based on the scopes defined in the scopes file.
+# Author: teh@digdir.no
+# -----------------------------------------------------------------------------------------------------------------
+# NOTE! Requires a "scopes-admin.config.local.cmd" file present in same directory as script.
+# -----------------------------------------------------------------------------------------------------------------
+#
+# Examples: 
+# .\so-patch report -env test -org 991825827                  --> Generates a report showing expected and actual access to scopes for one org
+# .\so-patch patch -env test -org 991825827                   --> Gives org access to all scopes defined in scopes.local.json
+# .\so-patch patch_all -env test -scope someprefix:somescope  --> Perfect if introducing a new scope you want all application owners to have access to
+#
+
+[cmdletbinding()]
+param (
+    [Parameter(Mandatory=$true)][string]$Operator,
+    [Parameter(Mandatory=$true)][string]$Env,
+    [Parameter(Mandatory=$false)][string]$Org,
+    [Parameter(Mandatory=$false)][string]$Scope
+)
+
+$ScopeAccess = ($PSScriptRoot + "\scopeaccess.ps1")
+
+function Get-Scopes {
+    $scopesfile = "$PSScriptRoot\scopes.local.json"
+    if (!(Test-Path $scopesfile)) {
+        Write-Warning "$scopesfile not found. Copy it from scopes.json"
+        Exit 1
+    }
+    $scopes = Get-Content -Raw -Path $scopesfile | ConvertFrom-Json 
+    $scopes.scopes
+}
+
+function Get-ServiceOwners {
+    param($env)
+
+    $sofile = "$PSScriptRoot\serviceowners.local.json"
+    if (!(Test-Path $sofile)) {
+        Write-Warning "$sofile not found. Copy it from serviceowners.json"
+        Exit 1
+    }
+
+    $fileContent = Get-Content -Raw -Path $sofile | ConvertFrom-Json 
+
+    $so = @{}
+    $fileContent.orgs.psobject.properties 
+        | ForEach-Object { $so[$_.Name] = $_.Value }
+    $so.Values 
+        | Where-Object { $_.environments -and $_.environments.Contains($env) } 
+        | Select-Object -ExpandProperty name -Property orgnr 
+        | ForEach-Object {
+            [PSCustomObject]@{
+                OrgNo   = $_.orgnr
+                Name   = $_.nb
+            }}
+}
+
+function Get-ReportOrg {
+    param($env, $org)
+    $scopes = Get-Scopes
+
+    $report = [ordered]@{}
+    foreach ($scope in $scopes) {
+        $report[$scope] = $false
+    }
+
+    $orgscopes = . $ScopeAccess -env $env -operator get -org $org
+    foreach ($orgscope in $orgscopes) {
+        Write-Verbose $orgscope
+        if ($report.Keys -contains $orgscope.scope -and $orgscope.state -eq "APPROVED") {
+            $report[$orgscope.scope] = $true
+        }
+    }
+    $report
+}
+
+function Patch-Org {
+    param($env, $org)
+
+    $report = Get-ReportOrg -env $env -org $org
+
+    $report | Format-Table -AutoSize
+
+    foreach ($item in $report.GetEnumerator()) {
+        if ($item.Value -eq $false) {
+            Write-Warning ("Giving $org access to " + $item.Key)
+            . $ScopeAccess -env $env -operator add -scope $item.Key -org $org
+        }
+    }
+}
+
+function Patch-All {
+    param($env, $scope)
+    
+    $scopes = Get-Scopes
+
+    if ($scopes -notcontains $scope) {
+        Write-Error "Scope $scope not found in scopes.local.json"
+        Exit 1
+    }
+
+    $orgs = Get-ServiceOwners -env $env
+
+    foreach ($org in $orgs) {
+        Write-Verbose ("Checking " + $org.Name + " ..." + $org.OrgNo)
+
+        $report = Get-ReportOrg -env $env -org $org.OrgNo
+        $report | Format-Table -AutoSize
+
+        if ($report[$scope] -eq $false) {
+            Write-Warning ("Giving " + $org.Name + " access to " + $scope)
+            . $ScopeAccess -env $env -operator add -scope $scope -org $org.OrgNo
+        }
+    }
+}
+
+
+# ----------------------------------------------------------------------------------------------------------------- #
+
+if ($Operator -eq "report") {
+    if ($Org -eq "") {
+        Write-Error "Organization number must be supplied"
+        Exit 1
+    }
+    Get-ReportOrg -env $Env -org $Org | Format-Table -AutoSize
+}
+
+if ($Operator -eq "patch") {
+    if ($Org -eq "") {
+        Write-Error "Organization number must be supplied"
+        Exit 1
+    }
+    Patch-Org -env $Env -org $Org
+}
+
+if ($Operator -eq "patch_all") {
+    if ($Scope -eq "") {
+        Write-Error "A scope must be supplied. Also remember that the scope must be defined in scopes.local.json"
+        Exit 1
+    }
+    Patch-All -env $Env -scope $Scope
+}

--- a/scripts/token.ps1
+++ b/scripts/token.ps1
@@ -27,7 +27,7 @@ function Get-Token {
         Exit 1
     }
 
-    $tgconfig = $PSScriptRoot + "/scopes-admin.config.local.cmd";
+    $tgconfig = $PSScriptRoot + "\scopes-admin.config.local.cmd";
     if (!(Test-Path $tgconfig)) {
         Write-Warning "$tgconfig not found. Copy it from scopes-admin.config.cmd"
         Exit 1


### PR DESCRIPTION
## Description
While making myself more comfortable with the already solid set of commands I ended up working on my own version of the so-admin script, so-patch. This use a list of scopes instead of assuming that all `serviceowner` scopes should be accessible for all service owners. It also makes it possible to add a scope without `serviceowner` in the name.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
